### PR TITLE
on backtesting attempt to load a pickled binance client

### DIFF
--- a/utils/automated-backtesting.py
+++ b/utils/automated-backtesting.py
@@ -271,6 +271,10 @@ if __name__ == "__main__":
     with open(args.cfgs, "rt") as f:
         cfgs = yaml.safe_load(f.read())
 
+    # clean up old binance client cache file
+    if os.path.exists("cache/binance.client"):
+        os.remove("cache/binance.client")
+
     with mp.Pool(processes=os.cpu_count() * 2) as pool:
         # process one strategy at a time
         for strategy in cfgs["STRATEGIES"]:


### PR DESCRIPTION
When running automated-backtesting we spin up a large number of binance clients,
each one of those will ping the api causing us to exceed the API limits.
This caches that client on disk in a pickled format and attempts to read it
if it already exists saving the other processes a trip to binance.