### PR TITLE
convert + to - on BTCDown strat

### DIFF
--- a/app.py
+++ b/app.py
@@ -1624,7 +1624,11 @@ class BuyDropSellRecoveryStrategyWhenBTCisDown(Bot):
         for _, n in last_period[1:]:
             if (
                 percent(
-                    100 + float(self.coins['BTCUSDT'].klines_slice_percentage_change),
+                    100 + (
+                        -abs(float(
+                            self.coins['BTCUSDT'].klines_slice_percentage_change
+                        ))
+                    ),
                     last_period_slice,
                 ) < n
             ):


### PR DESCRIPTION
Forces the strategy to use a negative percentage, even if we give it a positive value.
This is usefull when templating a large number of backtesting strategies such as
in the automated-backtesting runs. We can give the same values for the BTCup and
BTCdown strategies and they will be applied correctly.