### PR TITLE
skip if coin not in wallet when holding max coins

### DIFF
--- a/app.py
+++ b/app.py
@@ -1105,13 +1105,24 @@ class Bot:
 
     def process_line(self, line: str) -> None:
         """processes a backlog line"""
+
+        # skip processing the line if it doesn't not match our PAIRING settings
         if self.pairing not in line:
             return
 
         parts = line.split(" ", maxsplit=4)
         symbol = parts[2]
+        # skip processing the line if we don't care about this coin
         if symbol not in self.tickers:
             return
+
+        # skip processing the line we hold max coins and this coins is not in
+        # our wallet. Only process lines containing the coin in our wallets
+        # until we sell or drop those.
+        if len(self.wallet) >= self.max_coins:
+            if symbol not in self.wallet:
+                return
+
         day = " ".join(parts[0:2])
         try:
             # datetime is very slow, discard the .microseconds and fetch a


### PR DESCRIPTION
if we are holding the max number of coins, there's no point processing
all the lines during backtesting, as now would only care about price log
lines related to the coins we hold, so that we can sell them ASAP.

This simple change reduced backtesting times from:

```
2093.75s user 39.34s system 100% cpu 35:26.30 total
```

to

```
1077.57s user 34.27s system 101% cpu 18:14.77 total
```