### PR TITLE
Next release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,36 @@
 FROM bitnami/minideb:bullseye AS builder
 RUN install_packages \
-	make \
-	build-essential \
-	libssl-dev \
-	zlib1g-dev \
-	libbz2-dev \
-	libreadline-dev \
-	libsqlite3-dev \
-	wget \
-	curl \
-	llvm \
-	libncursesw5-dev \
-	xz-utils \
-	tk-dev \
-	libxml2-dev \
-	libxmlsec1-dev \
-	libffi-dev \
-	liblzma-dev \
-	git \
-	ca-certificates \
-	isal \
-	gzip \
-	pigz \
-	bzip2 \
-	pbzip2 \
-	isal \
-	libisal-dev \
-	libisal2 \
-	autoconf \
-	automake \
-	shtool \
-	coreutils \
-	autogen \
-	libtool \
-	shtool \
-	nasm
+  make \
+  build-essential \
+  libssl-dev \
+  zlib1g-dev \
+  libbz2-dev \
+  libreadline-dev \
+  libsqlite3-dev \
+  wget \
+  curl \
+  llvm \
+  libncursesw5-dev \
+  xz-utils \
+  tk-dev \
+  libxml2-dev \
+  libxmlsec1-dev \
+  libffi-dev \
+  liblzma-dev \
+  git \
+  ca-certificates \
+  gzip \
+  pigz \
+  bzip2 \
+  pbzip2 \
+  autoconf \
+  automake \
+  shtool \
+  coreutils \
+  autogen \
+  libtool \
+  shtool \
+  nasm
 
 
 RUN useradd -d /cryptobot -u 1001 -ms /bin/bash cryptobot
@@ -54,14 +50,11 @@ RUN C_INCLUDE_PATH=/cryptobot/.pyenv/versions/pyston-2.3.2/include/python3.8-pys
 
 FROM bitnami/minideb:bullseye AS cryptobot
 RUN install_packages \
-	xz-utils \
-	isal \
-	gzip \
-	pigz \
-	bzip2 \
-	pbzip2 \
-	isal \
-	libisal2
+  xz-utils \
+  gzip \
+  pigz \
+  bzip2 \
+  pbzip2
 
 RUN useradd -d /cryptobot -u 1001 -ms /bin/bash cryptobot
 USER cryptobot

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A python based trading bot for Binance, which relies heavily on backtesting.
    * [ENABLE_NEW_LISTING_CHECKS](#enable_new_listing_checks)
    * [ENABLE_NEW_LISTING_CHECKS_AGE_IN_DAYS](#enable_new_listing_checks_in_days)
    * [STOP_BOT_ON_LOSS](#stop_bot_on_loss)
+   * [ORDER_TYPE](#order type)
 6. [Bot command center](#bot-command-center)
 7. [Automated Backtesting](#automated-backtesting)
 8. [Obtaining old price log files](#obtaining-old-price-log-files)
@@ -683,6 +684,17 @@ STOP_BOT_ON_LOSS: True
 defaults to False
 
 Stops the bot immediately after a STOP_LOSS
+
+### ORDER_TYPE
+
+```
+ORDER_TYPE: "MARKET"
+```
+
+defaults to MARKET, available options are *MARKET* or *LIMIT*.
+
+Tells the BOT if it should use MARKET order or a LIMIT [FOK](https://academy.binance.com/en/articles/understanding-the-different-order-types) order.
+
 
 ## Bot command center
 

--- a/app.py
+++ b/app.py
@@ -380,7 +380,7 @@ class Coin:  # pylint: disable=too-few-public-methods
 
         return False
 
-    def new_listing(self, mode, days):
+    def new_listing(self, days):
         """checks if coin is a new listing"""
         # wait a few days before going to buy a new coin
         # since we list what coins we buy in TICKERS the bot would never
@@ -390,7 +390,7 @@ class Coin:  # pylint: disable=too-few-public-methods
         # we want to avoid buy these new listings as they are very volatile
         # and the bot won't have enough history to properly backtest a coin
         # looking for a profit pattern to use.
-        if mode == "backtesting" and len(self.averages["d"]) < days:
+        if len(self.averages["d"]) < days:
             return True
         return False
 
@@ -515,9 +515,7 @@ class Bot:
 
         # is this a new coin?
         if self.enable_new_listing_checks:
-            if coin.new_listing(
-                self.mode, self.enable_new_listing_checks_age_in_days
-            ):
+            if coin.new_listing(self.enable_new_listing_checks_age_in_days):
                 return
 
         # has the current price been influenced by a pump and dump?

--- a/app.py
+++ b/app.py
@@ -1266,6 +1266,8 @@ class Bot:
         coin.dip = float(0)
         coin.tip = float(0)
         coin.status = ""
+        coin.volume = float(0)
+        coin.value = float(0)
 
         # reset the min, max prices so that the bot won't look at all time high
         # and instead use the values since the last sale.

--- a/app.py
+++ b/app.py
@@ -592,6 +592,8 @@ class Bot:
         # we never place binance orders in backtesting mode.
         if self.mode in ["testnet", "live"]:
             try:
+                precision = f".{self.get_symbol_precision(coin.symbol)}f"
+
                 now = udatetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
                 logging.info(
                     f"{now}: {coin.symbol} [BUYING] {volume} of {coin.symbol} at {coin.price}"
@@ -603,7 +605,7 @@ class Bot:
                         type="LIMIT",
                         quantity=volume,
                         timeInForce="FOK",
-                        price=str(coin.price),
+                        price=format(coin.price, precision)
                     )
                 else:
                     order_details = self.client.create_order(
@@ -734,6 +736,8 @@ class Bot:
         # in backtesting mode, we never place sell orders on binance
         if self.mode in ["testnet", "live"]:
             try:
+                precision = f".{self.get_symbol_precision(coin.symbol)}f"
+
                 now = udatetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
                 logging.info(
                     f"{now}: {coin.symbol} [SELLING] {coin.volume} of {coin.symbol} at {coin.price}"
@@ -745,7 +749,7 @@ class Bot:
                         type="LIMIT",
                         quantity=coin.volume,
                         timeInForce="FOK",
-                        price=str(coin.price),
+                        price=format(coin.price, precision)
                     )
                 else:
                     order_details = self.client.create_order(

--- a/app.py
+++ b/app.py
@@ -968,7 +968,19 @@ class Bot:
         """creates a new coin or updates its price with latest binance data"""
         symbol = binance_data["symbol"]
 
-        market_price = float(binance_data["price"])
+        if symbol not in self.coins:
+            market_price = float(binance_data["price"])
+        else:
+            if self.coins[symbol].status == "TARGET_DIP":
+                order_book = self.client.get_order_book(symbol=symbol)
+                market_price = float(order_book["asks"][0][0])
+                logging.debug(
+                    f"{symbol} in TARGET_DIP using order_book price:"
+                    + f" {market_price}"
+                )
+            else:
+                market_price = float(binance_data["price"])
+
         # add every single coin to our coins dict, even if they're coins not
         # listed in our tickers file as the bot will use this info to record
         # the price.logs as well as cache/ data.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     image: ${IMAGE:-ghcr.io/azulinho/cryptobot}:${TAG:-latest}
     user: "${U}:${G}"
     build: ./
-    privileged: true
+    privileged: false
     environment:
       SMP_MULTIPLIER: "${SMP_MULTIPLIER:-1}"
 

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -1,5 +1,6 @@
 """ helpers module """
 import logging
+import math
 import pickle
 from datetime import datetime
 from functools import lru_cache
@@ -90,3 +91,25 @@ def cached_binance_client(access_key: str, secret_key: str) -> Client:
                 pickle.dump(_client, f)
 
         return _client
+
+
+def step_size_to_precision(step_size: str) -> int:
+    """returns step size"""
+    return step_size.find("1") - 1
+
+
+def floor_value(val: float, step_size: str) -> str:
+    """floors quantity depending on precision"""
+    precision = step_size_to_precision(step_size)
+    if precision > 0:
+        return "{:0.0{}f}".format(  # pylint: disable=consider-using-f-string
+            val, precision
+        )
+    return str(math.floor(int(val)))
+
+
+def truncate_value(val: float, step_size_str: str) -> str:
+    precision = step_size_to_precision(step_size_str)
+    if precision > 0:
+        return str("{:0.0{}f}".format(val, precision))
+    return str(math.trunc(int(val)))

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -106,10 +106,3 @@ def floor_value(val: float, step_size: str) -> str:
             val, precision
         )
     return str(math.floor(int(val)))
-
-
-def truncate_value(val: float, step_size_str: str) -> str:
-    precision = step_size_to_precision(step_size_str)
-    if precision > 0:
-        return str("{:0.0{}f}".format(val, precision))
-    return str(math.trunc(int(val)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ dateparser==1.1.0
 frozenlist==1.2.0
 idna==3.3
 intervaltree==3.1.0
-isal==0.11.1
 lz4==3.1.3
 multidict==5.2.0
 mypy==0.910

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ typing-extensions==3.10.0.2
 tzdata==2021.5
 tzlocal==4.1
 udatetime==0.0.16
-ujson==5.2.0
+ujson==5.4.0
 urllib3==1.26.7
 web-pdb==1.5.7
 websockets==9.1

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 ;addopts = --disable-socket --allow-unix-socket
 addopts = -n 4
+timeout = 10

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -335,7 +335,7 @@ class TestBot:
                     ],
                 ) as _:
                     with mock.patch.object(
-                        bot, "get_symbol_precision", return_value=1
+                        bot, "get_step_size", return_value="0.00001000"
                     ) as _:
                         assert bot.sell_coin(coin) is True
                         assert bot.wallet == []
@@ -372,7 +372,7 @@ class TestBot:
                 },
             ) as _:
                 with mock.patch.object(
-                    bot, "get_symbol_precision", return_value=1
+                    bot, "get_step_size", return_value="0.00001000"
                 ) as _:
                     assert bot.sell_coin(coin) is True
                     assert bot.wallet == []
@@ -380,7 +380,7 @@ class TestBot:
                     assert float(coin.bought_at) == float(0)
                     assert float(coin.value) == float(0.0)
 
-    def test_get_symbol_precision(self, bot):
+    def test_get_step_size(self, bot):
         with mock.patch.object(
             bot.client,
             "get_symbol_info",
@@ -389,15 +389,15 @@ class TestBot:
                 "filters": [{}, {}, {"stepSize": "0.1"}],
             },
         ) as _:
-            result = bot.get_symbol_precision("BTCUSDT")
-            assert result == 1
+            result = bot.get_step_size("BTCUSDT")
+            assert result == "0.00001000"
 
     def test_extract_order_data(self):
         pass
 
     def test_calculate_volume_size(self, bot, coin):
         with mock.patch.object(
-            bot, "get_symbol_precision", return_value=1
+            bot, "get_step_size", return_value="0.00001000"
         ) as _:
             volume = bot.calculate_volume_size(coin)
             assert volume == 0.5
@@ -469,7 +469,7 @@ class TestBot:
                 return_value=[{"symbol": "BTCUSDT", "orderId": 1}],
             ) as _:
                 with mock.patch.object(
-                    bot, "get_symbol_precision", return_value=1
+                    bot, "get_step_size", return_value="0.00001000"
                 ) as _:
                     binance_data = [
                         {"symbol": "BTCUSDT", "price": "101.000"},
@@ -888,7 +888,7 @@ class TestBuyCoin:
         bot.buy_coin(coin)
         assert bot.wallet == []
 
-    @mock.patch("app.Bot.get_symbol_precision", return_value=1)
+    @mock.patch("app.Bot.get_step_size", return_value="0.00001000")
     def test_buy_coin_in_backtesting(self, _, bot, coin):
         bot.mode = "backtesting"
         coin.price = 100
@@ -945,7 +945,7 @@ class TestBuyCoin:
                     ],
                 ) as _:
                     with mock.patch.object(
-                        bot, "get_symbol_precision", return_value=1
+                        bot, "get_step_size", return_value="0.00001000"
                     ) as _:
 
                         assert bot.buy_coin(coin) is True
@@ -980,7 +980,7 @@ class TestBuyCoin:
                 },
             ) as _:
                 with mock.patch.object(
-                    bot, "get_symbol_precision", return_value=1
+                    bot, "get_step_size", return_value="0.00001000"
                 ) as _:
 
                     assert bot.buy_coin(coin) is True

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,11 +1,12 @@
-import sys
-
-sys.path.insert(0, "")
-sys.path.insert(0, "")
-
+""" pytests tests for app.py """
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+# pylint: disable=redefined-outer-name
+# pylint: disable=import-outside-toplevel
+# pylint: disable=no-self-use
 import json
-import socket
-from datetime import datetime, timedelta
+from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -37,7 +38,7 @@ def bot(cfg):
         mock1.return_value = None
         client = Client("FAKE", "FAKE")
 
-        with mock.patch("requests.get", return_value={}) as mock2:
+        with mock.patch("requests.get", return_value={}) as _:
 
             bot = app.Bot(client, "configfilename", cfg)
             bot.client.API_URL = "https://www.google.com"
@@ -104,7 +105,7 @@ class TestCoin:
         coin.naughty = True
         coin.naughty_date = float(udatetime.now().timestamp() - 3600)
         coin.update(float(udatetime.now().timestamp()), 100.0)
-        assert coin.naughty == False
+        assert coin.naughty is False
 
     def test_update_coin_in_naughty_remains_naughty_before_timeout_(
         self, coin
@@ -113,7 +114,7 @@ class TestCoin:
         coin.naughty = True
         coin.naughty_date = float(udatetime.now().timestamp() - 3600)
         coin.update(float(udatetime.now().timestamp()), 100.0)
-        assert coin.naughty == True
+        assert coin.naughty is True
 
     def test_update_reached_new_min(self, coin):
         coin.min = 200
@@ -164,7 +165,7 @@ class TestCoin:
 
         assert len(coin.averages["m"]) == 2
 
-        for d, v in list(coin.averages["s"]):
+        for _, v in list(coin.averages["s"]):
             assert v == 100
 
         assert list(coin.averages["m"])[0][1] == 100.0
@@ -178,7 +179,7 @@ class TestCoin:
 
         assert len(coin.averages["m"]) == 60
 
-        for d, v in list(coin.averages["m"]):
+        for _, v in list(coin.averages["m"]):
             assert v == 100
 
         assert list(coin.averages["h"])[0][1] == 100.0
@@ -190,7 +191,7 @@ class TestCoin:
 
         assert len(coin.averages["h"]) == 24
 
-        for d, v in list(coin.averages["h"]):
+        for _, v in list(coin.averages["h"]):
             assert v == 100
 
         assert len(coin.averages["d"]) == 1
@@ -258,6 +259,7 @@ class TestCoin:
         assert coin.averages["h"][23] == (now - 3600, 100.0)
 
     def test_for_pump_and_dump_returns_true_on_pump(self, coin):
+        # pylint: disable=attribute-defined-outside-init
         self.enable_pump_and_dump_checks = True
         now = udatetime.now().timestamp()
 
@@ -378,7 +380,7 @@ class TestBot:
                     assert float(coin.bought_at) == float(0)
                     assert float(coin.value) == float(0.0)
 
-    def test_get_symbol_precision(self, bot, coin):
+    def test_get_symbol_precision(self, bot):
         with mock.patch.object(
             bot.client,
             "get_symbol_info",
@@ -386,7 +388,7 @@ class TestBot:
                 "symbol": "BTCUSDT",
                 "filters": [{}, {}, {"stepSize": "0.1"}],
             },
-        ) as m1:
+        ) as _:
             result = bot.get_symbol_precision("BTCUSDT")
             assert result == 1
 
@@ -396,20 +398,20 @@ class TestBot:
     def test_calculate_volume_size(self, bot, coin):
         with mock.patch.object(
             bot, "get_symbol_precision", return_value=1
-        ) as m1:
+        ) as _:
             volume = bot.calculate_volume_size(coin)
             assert volume == 0.5
 
-    def test_get_binance_prices(self, bot, coin):
+    def test_get_binance_prices(self, bot):
         pass
 
-    def test_init_or_update_coin(self, bot, coin, cfg):
+    def test_init_or_update_coin(self, bot, cfg):
         binance_data = {"symbol": "BTCUSDT", "price": "101.000"}
 
         bot.load_klines_for_coin = mock.Mock()
 
         result = bot.init_or_update_coin(binance_data)
-        assert result == None
+        assert result is None
 
         assert float(bot.coins["BTCUSDT"].price) == float(101.0)
         assert bot.coins["BTCUSDT"].buy_at_percentage == float(
@@ -460,15 +462,15 @@ class TestBot:
                     }
                 ],
             },
-        ) as m1:
+        ) as _:
             with mock.patch.object(
                 bot.client,
                 "get_all_orders",
                 return_value=[{"symbol": "BTCUSDT", "orderId": 1}],
-            ) as m2:
+            ) as _:
                 with mock.patch.object(
                     bot, "get_symbol_precision", return_value=1
-                ) as m3:
+                ) as _:
                     binance_data = [
                         {"symbol": "BTCUSDT", "price": "101.000"},
                         {"symbol": "BTCUSDT", "price": "70.000"},
@@ -476,7 +478,7 @@ class TestBot:
                     ]
                     with mock.patch.object(
                         bot, "get_binance_prices", return_value=binance_data
-                    ) as m4:
+                    ) as _:
                         with mock.patch.object(
                             bot, "run_strategy", return_value=None
                         ) as m5:
@@ -516,10 +518,11 @@ class TestBot:
             seconds = seconds + 60
 
         coin.date = date + seconds
+        # pylint: disable=protected-access
         r._content = json.dumps(response).encode("utf-8")
 
-        with mock.patch("requests.get", return_value=r) as mock2:
-            app.open = mock.mock_open()
+        with mock.patch("requests.get", return_value=r) as _:
+            # app.open = mock.mock_open()
             bot.load_klines_for_coin(coin)
 
         # upstream we retrieve 1000 days of history, but we only mock 60 days
@@ -886,7 +889,7 @@ class TestBuyCoin:
         assert bot.wallet == []
 
     @mock.patch("app.Bot.get_symbol_precision", return_value=1)
-    def test_buy_coin_in_backtesting(self, mocked, bot, coin):
+    def test_buy_coin_in_backtesting(self, _, bot, coin):
         bot.mode = "backtesting"
         coin.price = 100
 
@@ -1011,12 +1014,12 @@ class TestCoinStatus:
                     }
                 ],
             },
-        ) as m1:
+        ) as _:
             with mock.patch.object(
                 bot.client,
                 "get_all_orders",
                 return_value=[{"symbol": "BTCUSDT", "orderId": 1}],
-            ) as m2:
+            ) as _:
                 bot.stop_loss(coin)
                 assert bot.wallet == []
                 assert bot.profit == -80.12
@@ -1047,15 +1050,15 @@ class TestCoinStatus:
                     }
                 ],
             },
-        ) as m1:
+        ) as _:
             with mock.patch.object(
                 bot.client,
                 "get_all_orders",
                 return_value=[{"symbol": "BTCUSDT", "orderId": 1}],
-            ) as m2:
+            ) as _:
 
                 result = bot.coin_gone_up_and_dropped(coin)
-                assert result == True
+                assert result is True
                 assert bot.wins == 1
                 assert bot.profit == -99.101
                 assert round(bot.investment, 1) == round(0.89, 1)
@@ -1086,20 +1089,20 @@ class TestCoinStatus:
                     }
                 ],
             },
-        ) as m1:
+        ) as _:
             with mock.patch.object(
                 bot.client,
                 "get_all_orders",
                 return_value=[{"symbol": "BTCUSDT", "orderId": 1}],
-            ) as m2:
+            ) as _:
 
                 result = bot.possible_sale(coin)
-                assert result == True
+                assert result is True
                 assert bot.wins == 1
                 assert bot.profit == 99.7
                 assert round(bot.investment, 1) == round(199.7, 1)
 
-    def test_past_hard_limit(self, bot, coin, cfg):
+    def test_past_hard_limit(self, bot, coin):
         bot.wallet = ["BTCUSDT"]
         coin.bought_at = 100
         coin.cost = 100
@@ -1125,15 +1128,15 @@ class TestCoinStatus:
                     }
                 ],
             },
-        ) as m1:
+        ) as _:
             with mock.patch.object(
                 bot.client,
                 "get_all_orders",
                 return_value=[{"symbol": "BTCUSDT", "orderId": 1}],
-            ) as m2:
+            ) as _:
 
                 result = bot.past_hard_limit(coin)
-                assert result == True
+                assert result is True
                 assert bot.stales == 1
                 assert bot.profit == 99.7
                 assert coin.naughty_timeout == int(
@@ -1167,15 +1170,15 @@ class TestCoinStatus:
                     }
                 ],
             },
-        ) as m1:
+        ) as _:
             with mock.patch.object(
                 bot.client,
                 "get_all_orders",
                 return_value=[{"symbol": "BTCUSDT", "orderId": 1}],
-            ) as m2:
+            ) as _:
 
                 result = bot.past_soft_limit(coin)
-                assert result == True
+                assert result is True
                 assert coin.naughty_timeout == int(
                     bot.tickers["BTCUSDT"]["NAUGHTY_TIMEOUT"]
                 )
@@ -1212,7 +1215,7 @@ class TestCoinStatus:
         coin.min = float(9999)
 
         result = bot.clear_coin_stats(coin)
-        assert result == None
+        assert result is None
         assert coin.status == ""
         assert coin.holding_time == 1
         assert (
@@ -1254,14 +1257,14 @@ class TestBotProfit:
 
     def test_update_bot_profit_returns_None(self, bot, coin):
         result = bot.update_bot_profit(coin)
-        assert result == None
+        assert result is None
 
     def test_update_bot_profit_on_profit(self, bot, coin):
         coin.cost = 100
         coin.value = 200
         coin.profit = 100
 
-        result = bot.update_bot_profit(coin)
+        bot.update_bot_profit(coin)
         # bought 100 of coin and paid 0.1% of fees which is 0.10
         # sold 200 of coin and paid 0.1% of fees which is 0.20
         assert float(round(bot.fees, 1)) == float(0.3)
@@ -1272,7 +1275,7 @@ class TestBotProfit:
         coin.value = 100
         coin.profit = -10
 
-        result = bot.update_bot_profit(coin)
+        bot.update_bot_profit(coin)
         # bought 110 of coin and paid 0.1% of fees which is 0.11
         # sold 100 of coin and paid 0.1% of fees which is 0.10
         assert bot.profit == -10.21
@@ -1291,7 +1294,7 @@ class StrategyBaseTestClass:
             coin.averages["h"].append((datetime.now().timestamp(), 9999))
 
         result = bot.buy_strategy(coin)
-        assert result == False
+        assert result is False
         assert coin.status == "TARGET_DIP"
 
     def test_returns_early_when_coin_is_not_TARGET_DIP(self, bot, coin):
@@ -1299,7 +1302,7 @@ class StrategyBaseTestClass:
         coin.price = 100
         coin.max = 100
         result = bot.buy_strategy(coin)
-        assert result == False
+        assert result is False
         assert coin.status == ""
 
 
@@ -1314,7 +1317,7 @@ class TestStrategyBuyDropSellRecovery(StrategyBaseTestClass):
             mock1.return_value = None
             client = Client("FAKE", "FAKE")
 
-            with mock.patch("requests.get", return_value={}) as mock2:
+            with mock.patch("requests.get", return_value={}) as _:
 
                 bot = Strategy(client, "configfilename", cfg)
                 bot.client.API_URL = "https://www.google.com"
@@ -1329,7 +1332,7 @@ class TestStrategyBuyDropSellRecovery(StrategyBaseTestClass):
         coin.last = 100
         with mock.patch.object(bot, "buy_coin", return_value=False) as m1:
             result = bot.buy_strategy(coin)
-            assert result == False
+            assert result is False
             assert coin.status == "TARGET_DIP"
             m1.assert_not_called()
 
@@ -1344,7 +1347,7 @@ class TestStrategyBuyDropSellRecovery(StrategyBaseTestClass):
 
         with mock.patch.object(bot, "buy_coin", return_value=False) as m1:
             result = bot.buy_strategy(coin)
-            assert result == True
+            assert result is True
             assert coin.status == "TARGET_DIP"
             m1.assert_called()
 
@@ -1360,7 +1363,7 @@ class TestStrategyMoonSellRecovery:
             mock1.return_value = None
             client = Client("FAKE", "FAKE")
 
-            with mock.patch("requests.get", return_value={}) as mock2:
+            with mock.patch("requests.get", return_value={}) as _:
 
                 bot = Strategy(client, "configfilename", cfg)
                 bot.client.API_URL = "https://www.google.com"
@@ -1376,7 +1379,7 @@ class TestStrategyMoonSellRecovery:
         coin.last = 100
         with mock.patch.object(bot, "buy_coin", return_value=False) as m1:
             result = bot.buy_strategy(coin)
-            assert result == False
+            assert result is False
             m1.assert_not_called()
 
     def test_bot_buys_coin_when_price_above_buy_at_percentage(self, bot, coin):
@@ -1389,7 +1392,7 @@ class TestStrategyMoonSellRecovery:
 
         with mock.patch.object(bot, "buy_coin", return_value=True) as m1:
             result = bot.buy_strategy(coin)
-            assert result == True
+            assert result is True
             m1.assert_called()
 
 
@@ -1404,7 +1407,7 @@ class TestStrategyBuyOnGrowthTrendAfterDrop(StrategyBaseTestClass):
             mock1.return_value = None
             client = Client("FAKE", "FAKE")
 
-            with mock.patch("requests.get", return_value={}) as mock2:
+            with mock.patch("requests.get", return_value={}) as _:
 
                 bot = Strategy(client, "configfilename", cfg)
                 bot.client.API_URL = "https://www.google.com"
@@ -1428,7 +1431,7 @@ class TestStrategyBuyOnGrowthTrendAfterDrop(StrategyBaseTestClass):
 
         with mock.patch.object(bot, "buy_coin", return_value=True) as m1:
             result = bot.buy_strategy(coin)
-            assert result == False
+            assert result is False
             assert coin.status == "TARGET_DIP"
             m1.assert_not_called()
 
@@ -1451,7 +1454,7 @@ class TestStrategyBuyOnGrowthTrendAfterDrop(StrategyBaseTestClass):
             result = bot.buy_strategy(coin)
             m1.assert_called()
             assert coin.status == "TARGET_DIP"
-            assert result == True
+            assert result is True
 
 
 class TestBacktesting:

--- a/utils/automated-backtesting.py
+++ b/utils/automated-backtesting.py
@@ -135,11 +135,13 @@ def gather_best_results_from_backtesting_log(log, minimum, kind, word, sortby):
                             }
                     else:
                         if w >= coins[coin]["w"]:
-                            # if this run has the same amount of wins but lower
-                            # profit, then keep the old one
+                            # if this run has the same amount of wins but higher
+                            # profit, then keep the old one.
+                            # we are aiming for the safest number of wins, not
+                            # the highest profit.
                             if (
                                 w == coins[coin]["w"]
-                                and profit < coins[coin]["profit"]
+                                and profit > coins[coin]["profit"]
                             ):
                                 continue
                             coins[coin] = {

--- a/utils/automated-backtesting.py
+++ b/utils/automated-backtesting.py
@@ -137,7 +137,10 @@ def gather_best_results_from_backtesting_log(log, minimum, kind, word, sortby):
                         if w >= coins[coin]["w"]:
                             # if this run has the same amount of wins but lower
                             # profit, then keep the old one
-                            if w == coins[coin]["w"] and profit < coins[coin]["profit"]:
+                            if (
+                                w == coins[coin]["w"]
+                                and profit < coins[coin]["profit"]
+                            ):
                                 continue
                             coins[coin] = {
                                 "profit": profit,
@@ -348,7 +351,6 @@ def main():
                         t.result()
                     except subprocess.TimeoutExpired as excp:
                         print(f"timeout while running: {excp}")
-
 
             # finally we soak up the backtesting.log and generate the best
             # config from all the runs in this strategy


### PR DESCRIPTION
bugfixes:

* igzip looks to be hanging, removed so that xopen won't use it
* reduce API calls in automated backtesting through the use of a lock
* checks the age (new_listing) of a coin in all running modes
* fixes for quantity and precision related to step_size (was failing when buying BTC pairs)

new stuff:

* first implementation for LIMIT orders (FOK)
* uses order book to set the price when a coin is TARGET_DIP

changes:
* in automated-backtesting for runs with the same number of wins, use the one with the lowest profit