### PR TITLE
automated-backtesting: use config with most profit

### DIFF
--- a/utils/automated-backtesting.py
+++ b/utils/automated-backtesting.py
@@ -144,12 +144,10 @@ def gather_best_results_from_backtesting_log(log, minimum, kind, word, sortby):
                     else:
                         if w >= coins[coin]["w"]:
                             # if this run has the same amount of wins but higher
-                            # profit, then keep the old one.
-                            # we are aiming for the safest number of wins, not
-                            # the highest profit.
+                            # profit, then keep this one.
                             if (
                                 w == coins[coin]["w"]
-                                and profit > coins[coin]["profit"]
+                                and profit < coins[coin]["profit"]
                             ):
                                 continue
                             coins[coin] = {


### PR DESCRIPTION
previously, when two configs runs in the same automated-backtesting
session, provided the bot with the same number of wins for the same
coin, the bot would take the config with the smallest profit. This
behaviour was assuming that it was a lower risk and likely to provide
better results over time ( less losses ).
However a test build using the change in this PR, shows that in a
prove-backtesting over multiple days, where we pick the config with the
most profit provides considerable better returns.