### PR TITLE
FILTER was not being consumed

### DIFF
--- a/run
+++ b/run
@@ -10,7 +10,7 @@ function usage() {
 	echo "./run lastfewdays DAYS=3 PAIR=USDT"
 	echo "./run automated-backtesting LOGFILE=lastfewdays.log.gz CONFIG_FILE=backtesting.yaml MIN=10 FILTER='' SORTBY='profit|wins'"
 	echo "./run download-price-logs FROM=20210101 TO=20211231"
-	echo "./run prove-backtesting CONFIG_FILE=myconfig.yaml FROM=20220101 BACKTRACK=90 MIN=20 FORWARD=30 TO=20220901 SORTBY=profit|wins"
+	echo "./run prove-backtesting CONFIG_FILE=myconfig.yaml FROM=20220101 BACKTRACK=90 MIN=20 FORWARD=30 TO=20220901 SORTBY=profit|wins FILTER=''"
 	echo "./run config-endpoint-service BIND=0.0.0.0 CONFIG_FILE=myconfig.yaml BACKTRACK=30 PAIRING=USDT MIN=10 TUNED_CONFIG=BuyDropSellRecoveryStrategy.yaml SORTBY=wins|profit"
 	echo "./run klines-caching-service BIND=0.0.0.0"
 	echo "./run download_price_logs FROM=20220101 TO=20220131"
@@ -175,7 +175,7 @@ function automated_backtesting() { # runs the automated backtesting
 		${DOCKER_MOUNTS} \
 		${DOCKER_NETWORK} \
 		-e LOGFILE=/cryptobot/log/${LOGFILE} \
-		-e CONFIG=/cryptobot/configs/${CONFIG_FILE} \
+		-e CONFIG_FILE=/cryptobot/configs/${CONFIG_FILE} \
 		-e MIN=${MIN} \
 		-e FILTER=${FILTER} \
 		-e SORTBY=${SORTBY} \
@@ -218,7 +218,7 @@ function prove_backtesting() { # runs the prove backtesting
 	fi
 
 	RESULTS_LOG="${RESULTS_DIR}/prove-backtesting"
-	RESULTS_LOG="${RESULTS_LOG}.${CONFIG}"
+	RESULTS_LOG="${RESULTS_LOG}.${CONFIG_FILE}"
 	RESULTS_LOG="${RESULTS_LOG}.min${MIN}"
 	RESULTS_LOG="${RESULTS_LOG}.${SORTBY}"
 	RESULTS_LOG="${RESULTS_LOG}.${FROM}_${TO}"
@@ -237,6 +237,7 @@ function prove_backtesting() { # runs the prove backtesting
 		-e MIN=${MIN} \
 		-e FORWARD=${FORWARD} \
 		-e TO=${TO} \
+		-e FILTER=${FILTER} \
 		-e SORTBY=${SORTBY} \
 		-e SMP_MULTIPLIER=${SMP_MULTIPLIER} \
 		${IMAGE}:${TAG} \

--- a/utils/automated-backtesting.py
+++ b/utils/automated-backtesting.py
@@ -30,7 +30,7 @@ def compress_file(filename):
     os.remove(filename)
 
 
-def split_logs_into_coins(filename, cfg, logs_dir="log"):
+def split_logs_into_coins(filename, cfg, filterby, logs_dir="log"):
     """splits one price.log into individual coin price.log files"""
     coinfiles = set()
     coinfh = {}
@@ -40,10 +40,14 @@ def split_logs_into_coins(filename, cfg, logs_dir="log"):
 
             # don't process all the lines, but only the ones related to our PAIR
             # 2021-01-01 00:00:01.0023 BTCUSDT 36000.00
-            if not f"{pairing} " in line:
+            if not f"{pairing} " in str(line):
                 continue
 
-            parts = line.split(" ")
+            # and constrain to our filterby
+            if not f"{filterby} " in str(line):
+                continue
+
+            parts = str(line).split(" ")
             symbol = parts[2]
 
             # don't process any BEAR/BULL/UP/DOWN lines
@@ -565,7 +569,7 @@ def main():
         run_final_backtest,
     ) = cli()
 
-    coinfiles = split_logs_into_coins(logfile, cfgs, logs_dir="log")
+    coinfiles = split_logs_into_coins(logfile, cfgs, filterby, logs_dir="log")
 
     if os.path.exists("cache/binance.client"):
         os.remove("cache/binance.client")

--- a/utils/automated-backtesting.sh
+++ b/utils/automated-backtesting.sh
@@ -2,4 +2,4 @@
 ulimit -n 65535
 source /cryptobot/.venv/bin/activate
 python -u utils/automated-backtesting.py \
-	-l ${LOGFILE} -c ${CONFIG} -m ${MIN} -f "${FILTER}" -s "${SORTBY}"
+	-l ${LOGFILE} -c ${CONFIG_FILE} -m ${MIN} -f "${FILTER}" -s "${SORTBY}"

--- a/utils/prove-backtesting.sh
+++ b/utils/prove-backtesting.sh
@@ -4,4 +4,4 @@ ulimit -n 65535
 source /cryptobot/.venv/bin/activate
 python -u /cryptobot/utils/prove-backtesting.py \
 	-d ${FROM} -b ${BACKTRACK} -c ${CONFIG_FILE} -m ${MIN} \
-	-f ${FORWARD} -e ${TO} -s ${SORTBY}
+	-f ${FORWARD} -e ${TO} -s ${SORTBY} -x "${FILTER}" -n ${SMP_MULTIPLIER}


### PR DESCRIPTION
FILTER was not being consumed in prove-backtesting and
automated-backtesting runs.
this commit, makes sure we can filter on a word like 'BTCUSDT' and the
tooling will only create logfiles or run backtesting on lines that
contain that word.
This allows us to quickly backtesting a single coin