### PR TITLE
builts alternative python intr builds

### DIFF
--- a/.github/workflows/build_tag_cryptobot_img.yaml
+++ b/.github/workflows/build_tag_cryptobot_img.yaml
@@ -43,3 +43,47 @@ jobs:
           labels: ${{ steps.meta_cryptobot_img.outputs.labels }}
           push: true
           no-cache: true
+
+      - name: sets python version to pyston
+        run: |
+          echo pyston-2.3.5 > .python-version
+
+      - name: Docker meta ALT pyston cryptobot image
+        id: meta_alt_pyston_cryptobot_img
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/azulinho/cryptobot
+          tags: |
+            type=raw,value=pyston
+
+      - name: Push ALT pyston to GitHub Packages
+        uses: docker/build-push-action@v2
+        with:
+          tags: ${{ steps.meta_cryptobot_img.outputs.tags }}
+          labels: ${{ steps.meta_cryptobot_img.outputs.labels }}
+          push: true
+          no-cache: false
+
+
+      - name: sets python version to pypy
+        run: |
+          echo pypy3.9-7.3.11 > .python-version
+
+      - name: Docker meta ALT pypy cryptobot image
+        id: meta_alt_pypy_cryptobot_img
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/azulinho/cryptobot
+          tags: |
+            type=raw,value=pypy
+
+      - name: Push ALT pypy to GitHub Packages
+        uses: docker/build-push-action@v2
+        with:
+          tags: ${{ steps.meta_cryptobot_img.outputs.tags }}
+          labels: ${{ steps.meta_cryptobot_img.outputs.labels }}
+          push: true
+          no-cache: false
+
+
+


### PR DESCRIPTION
pyston has been the default python used in cryptobot until the pyston
team decided to move their efforts into pyston-lite.
Shortly after, python 3.11 was released, with that cryptobot switched to
use 3.11 as the pyston future is well, dead?
My local testing shows me that 3.11 is actually a bit slower on certain
workloads that the bot uses, the largest blob of time is the mix of
ungzipping, and the split of the price.log into symbol, date, price.
For some reason pyston is still the fastest implementation for this kind
of workload.
On my local benchmarks for a set of test local test runs,
3.11 takes 4s for a local test run, while pyston takes 3s. With 3.10
slightly below 4s.

This PR adds docker tag builds for the :pyston and :pypy alongside the
:latest tag.
This will allow to consume a :pyston tag if someone wants the fastest
build for backtesting runs. I know I do.