### PR TITLE
next_release

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -16,3 +16,5 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-faster_fifo.*]
 ignore_missing_imports = True
+[mypy-faster_fifo_reduction.*]
+ignore_missing_imports = True

--- a/app.py
+++ b/app.py
@@ -6,7 +6,6 @@ import json
 import logging
 import sys
 import threading
-import traceback
 from os import getpid, unlink
 from os.path import exists
 
@@ -19,8 +18,8 @@ from lib.helpers import cached_binance_client
 
 # allow migration from old pickle format to new format
 # old pickle cointains app.Bot, app.Coin
-from lib.bot import Bot
-from lib.coin import Coin
+from lib.bot import Bot  # pylint: disable=unused-import
+from lib.coin import Coin  # pylint: disable=unused-import
 
 
 def control_center() -> None:

--- a/lib/bot.py
+++ b/lib/bot.py
@@ -1540,6 +1540,7 @@ class Bot:
             while True:
                 next_n_lines = list(islice(f, 131070))
                 if not next_n_lines:
+                    f.close()
                     break
                 payload = []
                 for line in next_n_lines:

--- a/lib/bot.py
+++ b/lib/bot.py
@@ -16,8 +16,6 @@ import udatetime
 import logging
 import pickle  # nosec
 import pprint
-import sys
-import traceback
 from datetime import datetime
 from itertools import islice
 from os import fsync, unlink
@@ -170,9 +168,7 @@ class Bot:
             "KLINES_CACHING_SERVICE_URL", "http://klines:8999"
         )
 
-    def extract_order_data(  # pylint: disable=no-self-use
-        self, order_details, coin
-    ) -> Dict[str, Any]:
+    def extract_order_data(self, order_details, coin) -> Dict[str, Any]:
         """calculate average price and volume for a buy order"""
 
         # Each order will be fullfilled by different traders, and made of
@@ -811,7 +807,7 @@ class Bot:
             if coin_symbol in self.wallet:
                 self.log_debug_coin(self.coins[coin_symbol])
 
-    def target_sell(self, coin: Coin) -> bool:  # pylint: disable=R0201
+    def target_sell(self, coin: Coin) -> bool:
         """
         Check for a coin we HOLD if we reached the SELL_AT_PERCENTAGE
         and mark that coin as TARGET_SELL if we have.
@@ -1201,9 +1197,15 @@ class Bot:
             logging.warning("found coins.json, loading coins")
             with open("state/coins.json", "rt") as f:
                 objects = dict(json.loads(f.read()))
-                for symbol in objects.keys():
+                for (
+                    symbol
+                ) in (
+                    objects.keys()
+                ):  # pylint: disable=consider-using-dict-items
                     self.init_or_update_coin(objects[symbol])
-                    for k, v in objects[symbol].items():
+                    for k, v in objects[
+                        symbol
+                    ].items():  # pylint: disable=consider-using-dict-items
                         # we load the klines from the init_or_update_coin()
                         # above so we should skip the data from the .json file
                         if k in ["lowest", "averages", "highest"]:
@@ -1393,7 +1395,7 @@ class Bot:
         return (False, "HOLD")
 
     def buy_strategy(
-        self, coin: Coin  # pylint: disable=unused-argument,R0201
+        self, coin: Coin  # pylint: disable=unused-argument
     ) -> bool:
         """buy strategy"""
         return False
@@ -1520,6 +1522,10 @@ class Bot:
         self.run_strategy(self.coins[symbol])
 
     def place_klines_into_q(self, cfg: Dict, q_klines: Queue):
+        """reads all price.logs spliting out symbol, date, price, placing
+        the data into a queue.
+        This function is called through a mp.Process()
+        """
         for logfile in cfg["PRICE_LOGS"]:
             logging.info(f"backtesting: {logfile}")
             logging.info(f"wallet: {self.wallet}")
@@ -1618,7 +1624,8 @@ class Bot:
                 + f"?symbol={coin.symbol}"
                 + f"&date={coin.date}"
                 + f"&mode={self.mode}"
-                + f"&debug={self.debug}"
+                + f"&debug={self.debug}",
+                timeout=30,
             )
             data = response.json()
         # TODO: rework this
@@ -1845,7 +1852,7 @@ class Bot:
     def refresh_config_from_config_endpoint_service(self) -> None:
         """updates the bot config (ticker list) from the config endpoint"""
         try:
-            r = requests.get(self.pull_config_address).json()
+            r = requests.get(self.pull_config_address, timeout=1).json()
             if r["md5"] == self.pull_config_md5:
                 return
 
@@ -1976,23 +1983,46 @@ class Bot:
 
         if unit != "m":
             coin.lowest[unit].append(
-                (date, min([v for _, v in coin.lowest[previous]]))
+                (
+                    date,
+                    min(  # pylint: disable=consider-using-generator
+                        [v for _, v in coin.lowest[previous]]
+                    ),
+                )
             )
             coin.averages[unit].append(
-                (date, mean([v for _, v in coin.averages[previous]]))
+                (
+                    date,
+                    mean([v for _, v in coin.averages[previous]]),
+                )  # pylint: disable=consider-using-generator
             )
             coin.highest[unit].append(
-                (date, max([v for _, v in coin.highest[previous]]))
+                (
+                    date,
+                    max(  # pylint: disable=consider-using-generator
+                        [v for _, v in coin.highest[previous]]
+                    ),
+                )
             )
         else:
             coin.lowest["m"].append(
-                (date, min([v for _, v in coin.averages["s"]]))
+                (
+                    date,
+                    min(  # pylint: disable=consider-using-generator
+                        [v for _, v in coin.averages["s"]]
+                    ),
+                )
             )
             coin.averages["m"].append(
                 (date, mean([v for _, v in coin.averages["s"]]))
             )
             coin.highest["m"].append(
-                (date, max([v for _, v in coin.averages["s"]]))
+                (
+                    date,
+                    max(  # pylint: disable=consider-using-generator
+                        [v for _, v in coin.averages["s"]]
+                    ),
+                )
             )
 
     def consolidate_averages(

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -52,7 +52,7 @@ def c_from_timestamp(date: float) -> datetime:
 @limiter.ratelimit("binance", delay=True)
 def requests_with_backoff(query: str):
     """retry wrapper for requests calls"""
-    response = requests.get(query)
+    response = requests.get(query, timeout=5)
 
     # 418 is a binance api limits response
     # don't raise a HTTPError Exception straight away but block until we are

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,4 @@ websockets==9.1
 Werkzeug==2.2.2
 yarl==1.8.2
 zipp==3.8.1
+pyzmq==24.0.1

--- a/run
+++ b/run
@@ -356,6 +356,7 @@ function tests() { # CI and pre-commit tests
 
 function github_actions_ci_pr_docker_tests() {
 	set -ex
+  ./run down
   ./run build TAG=pr
   ./run klines-caching-service RUN_IN_BACKGROUND=yes TAG=pr
 
@@ -432,6 +433,7 @@ function github_actions_ci_pr_docker_tests() {
 	md5sum ${CONFIG_DIR}/BuyOnRecoveryAfterDropFromAverageStrategy.yaml \
 		|cut -f1 -d " " | grep 'dbb69758a3d2eb24041ec70cd4494a1e'
 
+  ./run down
 }
 
 function compress_logs() { # compresses the latest price logs

--- a/run
+++ b/run
@@ -346,7 +346,7 @@ function tests() { # CI and pre-commit tests
 	echo "running black..."
 	black --check app.py strategies/ lib/ tests/ utils/
 	echo "running pylint..."
-	ls strategies/*.py |grep -v Local | xargs pylint -E app.py lib/*.py utils/*.py
+	ls strategies/*.py |grep -v Local | xargs pylint app.py lib/*.py utils/*.py
 	echo "running mypy..."
 	ls strategies/*.py |grep -v Local | xargs mypy app.py lib/*.py utils/*.py
 	echo "running pytest..."

--- a/utils/automated-backtesting.py
+++ b/utils/automated-backtesting.py
@@ -457,7 +457,7 @@ def cli():
         args.config_dir,
         args.results_dir,
         args.logs_dir,
-        False if args.run_final_backtest != "True" else True,
+        not args.run_final_backtest != "True",
     ]
 
 

--- a/utils/automated-backtesting.py
+++ b/utils/automated-backtesting.py
@@ -483,9 +483,17 @@ def gather_best_results_from_run(coinfiles, sortby, results_dir):
         with open(results_txt) as f:
             run_results = f.read()
 
-        wins, losses, stales, holds = re.search(wins_re, run_results).groups()
-
-        balance = float(re.search(balance_re, run_results).groups()[0])
+        try:
+            wins, losses, stales, holds = re.search(
+                wins_re, run_results
+            ).groups()
+            balance = float(re.search(balance_re, run_results).groups()[0])
+        except AttributeError as e:
+            log_msg(f"Exception while collecting results from {results_txt}")
+            log_msg(e)
+            log_msg(f"Contents of file below: \n{run_results}")
+            wins, losses, stales, holds = [0, 0, 0, 0]
+            balance = 0
 
         if sortby == "wins":
             if (int(losses) + int(stales) + int(holds)) == 0:

--- a/utils/automated-backtesting.py
+++ b/utils/automated-backtesting.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 from collections import OrderedDict
 from datetime import datetime
-from multiprocessing import get_context
+from multiprocessing import Pool
 from string import Template
 from typing import Optional
 
@@ -73,7 +73,7 @@ def split_logs_into_coins(filename, cfg, filterby, logs_dir="log"):
 
     log_msg("compressing logfiles....")
     tasks = []
-    with get_context("spawn").Pool(processes=N_TASKS) as pool:
+    with Pool(processes=N_TASKS) as pool:
         for coin_filename in coinfiles:
             job = pool.apply_async(compress_file, (coin_filename,))
             tasks.append(job)
@@ -315,7 +315,7 @@ def generate_config_for_tuned_strategy(strategy, cfg, results, logfile):
 def run_tuned_config(strategies, config_dir, results_dir):
     """run final tuned config"""
     # run_tuned_config
-    with get_context("spawn").Pool(processes=N_TASKS) as pool:
+    with Pool(processes=N_TASKS) as pool:
         tasks = []
         for strategy in strategies:
             # first check if our config to test actually contain any tickers
@@ -370,7 +370,7 @@ def process_all_coin_files(
 ):
     """process all coin files"""
     tasks = []
-    with get_context("spawn").Pool(processes=N_TASKS) as pool:
+    with Pool(processes=N_TASKS) as pool:
         for coin in coinfiles:
             symbol = coin.split(".")[1]
             # then we backtesting this strategy run against each coin

--- a/utils/migrate_cache_files.py
+++ b/utils/migrate_cache_files.py
@@ -1,5 +1,4 @@
 """ migrates the cache files to the new symbol/file layout """
-from glob import glob
 from os import listdir, mkdir
 from os.path import exists
 from shutil import move

--- a/utils/prove-backtesting.py
+++ b/utils/prove-backtesting.py
@@ -122,12 +122,15 @@ def run_prove_backtesting(config, results_dir):
 
 
 def run_automated_backtesting(
-    config, min_profit, sortby, logs_dir="log", env={}, filterby=""
+    config, min_profit, sortby, logs_dir="log", env=None, filterby=""
 ):
     """calls automated-backtesting"""
+    if env is None:
+        env = {}
     subprocess.run(
         f"python -u utils/automated-backtesting.py -l {logs_dir}/lastfewdays.log.gz "
-        + f"-c configs/{config} -m {min_profit} -f '{filterby}' -s {sortby} --run-final-backtest=False",
+        + f"-c configs/{config} -m {min_profit} -f '{filterby}' -s {sortby}"
+        + " --run-final-backtest=False",
         shell=True,
         check=False,
         env=env,
@@ -135,7 +138,7 @@ def run_automated_backtesting(
 
 
 def create_zipped_logfile(
-    dates, pairing, logs_dir="log", symbols=[], filterby=""
+    dates, pairing, logs_dir="log", symbols=None, filterby=""
 ):
     """
     generates lastfewdays.log.gz from the provided list of price.log files
@@ -143,6 +146,8 @@ def create_zipped_logfile(
     also if symbols[] is provided, then only symbols in that list is used
     to generate the lastfewdays.log.gz
     """
+    if symbols is None:
+        symbols = []
     log_msg("creating gzip lastfewdays.log.gz")
 
     with open(f"{logs_dir}/lastfewdays.log", "wt") as w:


### PR DESCRIPTION
ungzip price.logs run on its own mp.Process()
split of lines into symbol, date, price runs on its own mp.Process()
swapped Queue() with faster-fifo using a larger queue size 8MB
pylint fixes

Queue work results in a saving of about 4 seconds out of a 14sec backtesting run