### PR TITLE
new modes: greed|max_profit_on_clean_wins|number_of_clean_wins 

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,7 +885,7 @@ This will generate a config.yaml with the coins sorted by which strategy
 returned the highest profit for each coin.
 
 ```
-./run automated-backtesting LOGFILE=lastfewdays.USDT.log.gz CONFIG_FILE=automated-backtesting.yaml MIN=10 FILTER='' SORTBY='profit'
+./run automated-backtesting LOGFILE=lastfewdays.USDT.log.gz CONFIG_FILE=automated-backtesting.yaml MIN=10 FILTER='' SORTBY='greed'
 ```
 
 This will generate a config.yaml with the coins sorted by which strategy
@@ -893,8 +893,18 @@ returned the highest number of clean wins for each coin. We call clean wins as
 bot runs that don't contain any losses, holds or stales, only wins.
 
 ```
-./run automated-backtesting LOGFILE=lastfewdays.USDT.log.gz CONFIG_FILE=automated-backtesting.yaml MIN=10 FILTER='' SORTBY='wins'
+./run automated-backtesting LOGFILE=lastfewdays.USDT.log.gz CONFIG_FILE=automated-backtesting.yaml MIN=10 FILTER='' SORTBY='number_of_clean_wins'
 ```
+
+This will generate a config.yaml with the coins sorted by which strategy
+returned the highest profit for each coin, where there weren't any stales,
+losses, or coins left in the wallet at the end of the run.
+
+```
+./run automated-backtesting LOGFILE=lastfewdays.USDT.log.gz CONFIG_FILE=automated-backtesting.yaml MIN=10 FILTER='' SORTBY='max_profit_on_clean_wins'
+```
+
+
 
 ## Prove automated-backtesting results
 
@@ -908,7 +918,7 @@ It then repeats this process starting the day after the last logfile
 backtested through the tuned config, all the way until the end date provided.
 
 ```
- ./run prove-backtesting FROM=20220801 BACKTRACK=90 MIN=9 CONFIG_FILE=backtesting.yaml TO=20220831 FORWARD=7 SORTBY=wins
+ ./run prove-backtesting FROM=20220801 BACKTRACK=90 MIN=9 CONFIG_FILE=backtesting.yaml TO=20220831 FORWARD=7 SORTBY=greed
 ```
 
 ## config-endpoint-service
@@ -918,7 +928,7 @@ automated-backtesting periodically, and having the LIVE bot pull that optimized
 config as soon automated-backtesting completes.
 
 ```
-./run config-endpoint-service BIND=0.0.0.0 CONFIG_FILE=myconfig.yaml BACKTRACK=30 PAIRING=USDT MIN=10 TUNED_CONFIG=BuyDropSellRecoveryStrategy.yaml SORTBY=wins|profit
+./run config-endpoint-service BIND=0.0.0.0 CONFIG_FILE=myconfig.yaml BACKTRACK=30 PAIRING=USDT MIN=10 TUNED_CONFIG=BuyDropSellRecoveryStrategy.yaml SORTBY=number_of_clean_wins
 ```
 
 see [PULL_CONFIG_ADDRESS]#pull_config_address and

--- a/run
+++ b/run
@@ -8,10 +8,10 @@ function usage() {
 	echo "./run live CONFIG_FILE=< config.yaml >"
 	echo "./run compress-logs"
 	echo "./run lastfewdays DAYS=3 PAIR=USDT"
-	echo "./run automated-backtesting LOGFILE=lastfewdays.log.gz CONFIG_FILE=backtesting.yaml MIN=10 FILTER='' SORTBY='profit|wins'"
+	echo "./run automated-backtesting LOGFILE=lastfewdays.log.gz CONFIG_FILE=backtesting.yaml MIN=10 FILTER='' SORTBY='greed|number_of_clean_wins|max_profit_on_clean_wins'"
 	echo "./run download-price-logs FROM=20210101 TO=20211231"
-	echo "./run prove-backtesting CONFIG_FILE=myconfig.yaml FROM=20220101 BACKTRACK=90 MIN=20 FORWARD=30 TO=20220901 SORTBY=profit|wins FILTER=''"
-	echo "./run config-endpoint-service BIND=0.0.0.0 CONFIG_FILE=myconfig.yaml BACKTRACK=30 PAIRING=USDT MIN=10 TUNED_CONFIG=BuyDropSellRecoveryStrategy.yaml SORTBY=wins|profit"
+	echo "./run prove-backtesting CONFIG_FILE=myconfig.yaml FROM=20220101 BACKTRACK=90 MIN=20 FORWARD=30 TO=20220901 SORTBY=greed|number_of_clean_wins|max_profit_on_clean_wins FILTER=''"
+	echo "./run config-endpoint-service BIND=0.0.0.0 CONFIG_FILE=myconfig.yaml BACKTRACK=30 PAIRING=USDT MIN=10 TUNED_CONFIG=BuyDropSellRecoveryStrategy.yaml SORTBY=greed|number_of_clean_wins|max_profit_on_clean_wins"
 	echo "./run klines-caching-service BIND=0.0.0.0"
 	echo "./run download_price_logs FROM=20220101 TO=20220131"
 }
@@ -211,7 +211,7 @@ function prove_backtesting() { # runs the prove backtesting
 		exit 1
 	fi
 	if [ -z "$SORTBY" ]; then
-		export SORTBY=wins
+		export SORTBY=number_of_clean_wins
 	fi
 	if [ -z "$SMP_MULTIPLIER" ]; then
 		export SMP_MULTIPLIER=1
@@ -272,7 +272,7 @@ function config_endpoint_service() { # runs the config endpoint service
 		exit 1
 	fi
 	if [ -z "$SORTBY" ]; then
-		export SORTBY=wins
+		export SORTBY=number_of_clean_wins
 	fi
 	if [ -z "$SMP_MULTIPLIER" ]; then
 		export SMP_MULTIPLIER=1
@@ -540,7 +540,7 @@ function main() { # main innit?
 	fi
 
 	if [ -z "$SORTBY" ]; then
-		export SORTBY="wins"
+		export SORTBY="number_of_clean_wins"
 	fi
 
 	if [ -z "$FILTER" ]; then

--- a/utils/config-endpoint-service.py
+++ b/utils/config-endpoint-service.py
@@ -137,7 +137,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "-b", "--backtrack", help="number of days to backtrack"
     )
-    parser.add_argument("-s", "--sortby", help="wins|profit")
+    parser.add_argument(
+        "-s",
+        "--sortby",
+        help="greed|number_of_clean_wins|max_profit_on_clean_wins",
+    )
     parser.add_argument(
         "-t",
         "--tuned-config",

--- a/utils/prove-backtesting.py
+++ b/utils/prove-backtesting.py
@@ -29,7 +29,10 @@ def cli():
     parser.add_argument("-m", "--min", help="min coin profit")
     parser.add_argument("-e", "--enddate", help="test until this date")
     parser.add_argument(
-        "-s", "--sortby", help="sortby results by profit/wins", default="wins"
+        "-s",
+        "--sortby",
+        help="sortby results by [greed|number_of_clean_wins|max_profit_on_clean_wins]",
+        default="number_of_clean_wins",
     )
     parser.add_argument(
         "-x", "--filter", help="filter coins by word", default=""


### PR DESCRIPTION
Swaps the automated-backtesting modes: *wins, profit* with new modes.

*number_of_clean_wins* is the same as the old 'wins' mode.
*greed* is the same as the old 'profit' mode.

the new mode:

*max_profit_on_clean wins*, simply looks for the maximum profit returned
across all backtesting runs that had no *losses, stales, holds* for the
same coin.