### PR TITLE
fix breakage in config-endpoint-service

### DIFF
--- a/utils/config-endpoint-service.py
+++ b/utils/config-endpoint-service.py
@@ -119,9 +119,9 @@ def root():
     with open(f"configs/{_tuned_config}") as f:
         cfg = yaml.safe_load(f.read())
         hashstr = hashlib.md5(
-            (json.dumps(config["TICKERS"], sort_keys=True)).encode("utf-8")
+            (json.dumps(cfg["TICKERS"], sort_keys=True)).encode("utf-8")
         ).hexdigest()
-        config["md5"] = hashstr
+        cfg["md5"] = hashstr
     return jsonify(cfg)
 
 


### PR DESCRIPTION
a pylint based change caused flask to explode on serving an unbound
variable.

we are lacking tests for the config-endpoint-service, which could have
prevented this from going into master.