### PR TITLE
use max-requests with gunicorn

### DIFF
--- a/run
+++ b/run
@@ -256,6 +256,8 @@ function price_log_service() { # runs the klines caching service
 			--workers=4 \
 			--worker-class=gevent \
 			--worker-connections=256 \
+			--max-requests=64 \
+			--max-requests-jitter=64 \
 			--worker-tmp-dir /dev/shm \
 			--bind 0.0.0.0:8998  price_log_service:app
 }


### PR DESCRIPTION
I noticed that gunicorn was *stalling* for around 25-30seconds
frequently, leading to CPU backtesting processing to drop.
Setting max-requests removed this stalling from happening.