### PR TITLE
don't skip lowest.average.highest on load_coins

### DIFF
--- a/lib/bot.py
+++ b/lib/bot.py
@@ -1198,15 +1198,6 @@ class Bot:
 
                         # pylint: disable=consider-using-dict-items
                         for k, v in objects[symbol].items():
-                            # we load the klines from the init_or_update_coin()
-                            # above so we should skip the data from the .json file
-                            # as this data might be very old
-                            if k in ["lowest", "averages", "highest"]:
-                                print(
-                                    f"ignoring likely stale {k} data from"
-                                    + f".json for {symbol}"
-                                )
-                                continue
                             setattr(self.coins[symbol], k, v)
 
             logging.warning(f"coins contains {str(self.coins.keys())}")


### PR DESCRIPTION
Since we're now keeping state between backtesting runs, we also want to
keep the coin state history for the lowest, average, highest values as
this will be up-to-date as soon we start a new run.

This might cause issues if in a LIVE run we stop the bot for long enough
that it can cause data to become stale. This can be avoided by using the
CLEAN_COINS_AT_BOOT flag