### PR TITLE
skip dupe condition check

### DIFF
--- a/run
+++ b/run
@@ -354,7 +354,7 @@ function github_actions_ci_pr_docker_tests() {
 		TAG=pr CONFIG_FILE=prove-backtesting.yaml
 
 	wc -l results/prove-backtesting.prove-backtesting.yaml.txt \
-		| grep '29'
+		| grep '44'
 
 	for ta in 01 02 03 04 05 06 07 08 09
 	do

--- a/utils/prove-backtesting.py
+++ b/utils/prove-backtesting.py
@@ -777,12 +777,6 @@ if __name__ == "__main__":
         price_logs = pv.generate_price_log_list(rollforward_dates)
         tickers = pv.gather_best_results_from_backtesting_log("coincfg")
 
-        # if our backtesting gave us no tickers,
-        # we'll skip this forward testing run
-        if not tickers:
-            log_msg("forwardtesting config contains no tickers, skipping run")
-            continue
-
         log_msg(
             f"now forwardtesting {rollforward_dates[0]}...{rollforward_dates[-1]}"
         )


### PR DESCRIPTION
This check is preventing prove-backtesting from running when it has a coin in the WALLET if no tickers were generated in the automated-backtesting phase