### PR TITLE
keep coin state in backtesting

### DIFF
--- a/lib/bot.py
+++ b/lib/bot.py
@@ -871,11 +871,7 @@ class Bot:
             if self.mode not in ["live", "backtesting", "testnet"]:
                 continue
 
-            # TODO: revisit this, as this function is only called in
-            # live, testnet and logmode. And the within this function, we
-            # expect to process all the coins.
-            # don't process any coins which we don't have in our config
-            if coin_symbol not in self.tickers:
+            if not coin_symbol.endswith(self.pairing):
                 continue
 
             # TODO: revisit this as the function below expects to process all

--- a/lib/bot.py
+++ b/lib/bot.py
@@ -1298,15 +1298,21 @@ class Bot:
 
             logging.warning(f"coins contains {str(self.coins.keys())}")
 
-        # sync our coins state with the list of coins we want to use.
-        # but keep using coins we currently have on our wallet
-        coins_to_remove: List[str] = []
-        for coin in self.coins:
-            if coin not in self.tickers and coin not in self.wallet:
-                coins_to_remove.append(coin)
+        # in backtesting, and mostly in a backtesting run from a prove-backtesting
+        # session. We load up the coin/wallet json files from tmp.
+        # in this scenario, we want to soak up all the coin files not just the
+        # ones we have in our tickets list. This is so that we have all the history
+        # we require to 'continue' our backtesting from 'where we left off'
+        if self.mode != "backtesting":
+            # sync our coins state with the list of coins we want to use.
+            # but keep using coins we currently have on our wallet
+            coins_to_remove: List[str] = []
+            for coin in self.coins:
+                if coin not in self.tickers and coin not in self.wallet:
+                    coins_to_remove.append(coin)
 
-        for coin in coins_to_remove:
-            del self.coins[coin]
+            for coin in coins_to_remove:
+                del self.coins[coin]
 
         # finally apply the current settings in the config file
         symbols: str = " ".join(self.coins.keys())

--- a/lib/bot.py
+++ b/lib/bot.py
@@ -1948,11 +1948,70 @@ class Bot:
             pp: pprint.PrettyPrinter = pprint.PrettyPrinter(indent=4)
             pp.pprint(self.tickers)
             self.pull_config_md5 = r["md5"]
-            # clean old coins data, or we will get errors later on
+            # fix old coins data, or we will get errors later on
             symbols: List[str] = list(self.coins.keys())
             for symbol in symbols:
                 if symbol not in self.tickers.keys():
-                    del self.coins[symbol]
+                    market_price = self.coins[symbol].price
+                    self.coins[symbol] = Coin(
+                        symbol,
+                        udatetime.now().timestamp(),
+                        market_price,
+                        buy_at=float(
+                            get_ticker_with_default(
+                                self.tickers, symbol, "BUY_AT_PERCENTAGE"
+                            )
+                        ),
+                        sell_at=float(
+                            get_ticker_with_default(
+                                self.tickers, symbol, "SELL_AT_PERCENTAGE"
+                            )
+                        ),
+                        stop_loss=float(
+                            get_ticker_with_default(
+                                self.tickers, symbol, "STOP_LOSS_AT_PERCENTAGE"
+                            )
+                        ),
+                        trail_target_sell_percentage=float(
+                            get_ticker_with_default(
+                                self.tickers,
+                                symbol,
+                                "TRAIL_TARGET_SELL_PERCENTAGE",
+                            )
+                        ),
+                        trail_recovery_percentage=float(
+                            get_ticker_with_default(
+                                self.tickers,
+                                symbol,
+                                "TRAIL_RECOVERY_PERCENTAGE",
+                            )
+                        ),
+                        soft_limit_holding_time=int(
+                            get_ticker_with_default(
+                                self.tickers, symbol, "SOFT_LIMIT_HOLDING_TIME"
+                            )
+                        ),
+                        hard_limit_holding_time=int(
+                            get_ticker_with_default(
+                                self.tickers, symbol, "HARD_LIMIT_HOLDING_TIME"
+                            )
+                        ),
+                        naughty_timeout=int(
+                            get_ticker_with_default(
+                                self.tickers, symbol, "NAUGHTY_TIMEOUT"
+                            )
+                        ),
+                        klines_trend_period=get_ticker_with_default(
+                            self.tickers, symbol, "KLINES_TREND_PERIOD"
+                        ),
+                        klines_slice_percentage_change=float(
+                            get_ticker_with_default(
+                                self.tickers,
+                                symbol,
+                                "KLINES_SLICE_PERCENTAGE_CHANGE",
+                            )
+                        ),
+                    )
             # we now need to update the config file, so that when we restart
             # the bot will have access to all the ticker info on any coins
             # it might be holding

--- a/lib/bot.py
+++ b/lib/bot.py
@@ -1365,22 +1365,6 @@ class Bot:
 
             logging.warning(f"coins contains {str(self.coins.keys())}")
 
-        # in backtesting, and mostly in a backtesting run from a prove-backtesting
-        # session. We load up the coin/wallet json files from tmp.
-        # in this scenario, we want to soak up all the coin files not just the
-        # ones we have in our tickets list. This is so that we have all the history
-        # we require to 'continue' our backtesting from 'where we left off'
-        if self.mode != "backtesting":
-            # sync our coins state with the list of coins we want to use.
-            # but keep using coins we currently have on our wallet
-            coins_to_remove: List[str] = []
-            for coin in self.coins:
-                if coin not in self.tickers and coin not in self.wallet:
-                    coins_to_remove.append(coin)
-
-            for coin in coins_to_remove:
-                del self.coins[coin]
-
         # finally apply the current settings in the config file
         symbols: str = " ".join(self.coins.keys())
         logging.warning(f"overriding values from config for: {symbols}")

--- a/lib/bot.py
+++ b/lib/bot.py
@@ -1780,6 +1780,7 @@ class Bot:
         data: Dict[str, Dict[str, List[List[float]]]] = {}
         # fetch all the available klines for this coin, for the last
         # 60min, 24h, and 1000 days
+        logging.debug("calling klines_caching_service_url")
         response: requests.Response = requests.get(
             self.klines_caching_service_url
             + f"?symbol={coin.symbol}"
@@ -1790,10 +1791,12 @@ class Bot:
         )
         data = response.json()
         if data:
+            logging.debug("klines_caching_service_url reponse: ok")
             ok = True
             coin.lowest = data["lowest"]
             coin.averages = data["averages"]
             coin.highest = data["highest"]
+            logging.debug(f"klines_caching_service_url reponse: {data}")
 
         return ok
 

--- a/lib/bot.py
+++ b/lib/bot.py
@@ -1511,8 +1511,6 @@ class Bot:
         # TODO: rework this, generate a binance_data blob to pass to
         # init_or_update_coin()
         if symbol not in self.coins:
-            if symbol not in self.tickers:
-                return
             if not symbol.endswith(self.cfg["PAIRING"]):
                 return
 

--- a/lib/bot.py
+++ b/lib/bot.py
@@ -6,7 +6,7 @@ import logging
 import pprint
 from datetime import datetime
 from functools import lru_cache
-from os import fsync, unlink
+from os import fsync, unlink, rename
 from os.path import basename, exists
 from time import sleep
 from typing import Any, Dict, List, Tuple
@@ -1244,10 +1244,11 @@ class Bot:
                     # corrupt the live .pickle files.
                     # in case or corruption, simply copy the .backup files over
                     # the .pickle files.
-                    with open(f"{statefile}.backup", "wb") as b:
+                    with open(f"{statefile}.tmp", "wb") as b:
                         b.write(f.read())
                         b.flush()
                         fsync(b.fileno())
+                    rename(f"{statefile}.tmp", f"{statefile}.backup")
 
         # convert .pyobject to a .json compatible format
         with open(state_coins, "wt") as f:

--- a/lib/bot.py
+++ b/lib/bot.py
@@ -1460,6 +1460,12 @@ class Bot:
                     + f"TTS:-{(100 - self.coins[symbol].trail_target_sell_percentage):.3f}% "
                     + f"LP:{self.coins[symbol].min:.3f} "
                 )
+
+            # let me know if our coin state is not clean
+            for symbol in self.coins.keys():  # pylint: disable=C0206,C0201
+                if self.coins[symbol].status:
+                    logging.info(f"{symbol}: {self.coins[symbol].status}")
+
             # make sure we unset .quit if its set from a previous run
             self.quit = False
 


### PR DESCRIPTION
keep coin state and history on all coins as we need all the back info during our prove-backtesting runs.
as to deal with coins for that are not defined in the tickers dict, we set BUY_AT and SELL_AT to values that they are never traded but that prevents the bot to crash